### PR TITLE
Allow customization on data and error

### DIFF
--- a/.jest/jest.config.js
+++ b/.jest/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   rootDir: path.resolve(__dirname, '..'),
   coverageDirectory: 'coverage',
   testMatch: [
-    '**/src/**/*.spec.js'
+    '**/src/**/*.spec.js',
   ],
-  setupFilesAfterEnv: [path.resolve(__dirname, 'utilities.setup.js')]
+  setupFilesAfterEnv: [path.resolve(__dirname, 'utilities.setup.js')],
 }

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 [![Build Status](https://travis-ci.org/beblueapp/redux-async.svg?branch=master)](https://travis-ci.org/beblueapp/redux-async)
 [![Code Coverage](https://codecov.io/gh/beblueapp/redux-async/branch/master/graph/badge.svg)](https://codecov.io/gh/beblueapp/redux-async)
-[![Code Quality](https://api.codacy.com/project/badge/Grade/b1e69af67fee4699aa886a6ac69e909d)](https://app.codacy.com/app/beblue-eng/redux-async?utm_source=github.com&utm_medium=referral&utm_content=beblueapp/redux-async&utm_campaign=Badge_Grade_Dashboard)
+[![Code Quality](https://api.codacy.com/project/badge/Grade/b1e69af67fee4699aa886a6ac69e909d)](https://app.codacy.com/app/beblue-eng/redux-async)
 ![Version](https://img.shields.io/npm/v/@beblueapp/redux-async.svg)
 ![License](https://img.shields.io/npm/l/@beblueapp/redux-async.svg)
-
 
 > There are only two hard things in Computer Science: cache invalidation and
 > naming things.
@@ -30,7 +29,7 @@ npm install @beblueapp/redux-async
 
 ## Usage
 
-There're two main components on `redux`, actions and reducers, for both, we've provided
+There're two main components on `redux`, actions and reducers. For both, we've provided
 helpers, the first will wrap your action and do the dynamic dispatches, and the second
 will receive that set of actions and control the state accordingly.
 

--- a/README.md
+++ b/README.md
@@ -51,17 +51,17 @@ export const fetchCustomers = createAC('FETCH_CUSTOMERS', index)
 
 // Component
 const Customers = ({ type, customers, fetchCustomers }) => {
-    useEffect(() => {
-        fetchCustomers(type)
-            .catch(({ response }) => console.log('An error has occured', response.data))
-    }, [type])
+  useEffect(() => {
+      fetchCustomers(type)
+          .catch(({ response }) => console.log('An error has occured', response.data))
+  }, [type])
 
 
-    return (customers.error
-     ? <div>Something bad happened: {customers.error.response.statusText}</div>
-     : <ul>
-        {customers.data.map(c => <li key={c.id}>{c.name}</li>)}
-    </ul>)
+  return (customers.error
+   ? <div>Something bad happened: {customers.error.response.statusText}</div>
+   : <ul>
+      {customers.data.map(c => <li key={c.id}>{c.name}</li>)}
+  </ul>)
 }
 ```
 
@@ -78,7 +78,7 @@ property of our state.
 import { createR } from '@beblueapp/redux-async'
 
 export combineReducers({
-    customers: createR('FETCH_CUSTOMERS')
+  customers: createR('FETCH_CUSTOMERS')
 })
 ```
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "75...100"
+
+  status:
+    project:
+      default:
+        target: 75%
+    patch:
+      default:
+        target: 75%
+    changes: no

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
-    "@beblueapp/eslint-config-base": "^0.0.2",
+    "@beblueapp/eslint-config-base": "^0.0.3",
     "babel-eslint": "^10.0.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/src/actions.js
+++ b/src/actions.js
@@ -2,7 +2,7 @@ export const STATUS = {
   IDLE: 'IDLE',
   PENDING: 'PENDING',
   FULFILLED: 'FULFILLED',
-  REJECTED: 'REJECTED'
+  REJECTED: 'REJECTED',
 }
 
 const prefixAT = name => `@@redux-async/${name}`
@@ -10,25 +10,25 @@ const createAT = (name, status) => `${prefixAT(name)}/${status}`
 
 const idle = name => ({
   type: createAT(name, STATUS.IDLE),
-  meta: { name, status: STATUS.IDLE }
+  meta: { name, status: STATUS.IDLE },
 })
 
 const pending = name => ({
   type: createAT(name, STATUS.PENDING),
-  meta: { name, status: STATUS.PENDING }
+  meta: { name, status: STATUS.PENDING },
 })
 
 const fulfilled = (name, payload) => ({
   type: createAT(name, STATUS.FULFILLED),
   payload,
-  meta: { name, status: STATUS.FULFILLED }
+  meta: { name, status: STATUS.FULFILLED },
 })
 
 const rejected = (name, error) => ({
   type: createAT(name, STATUS.REJECTED),
   payload: error,
   error: true,
-  meta: { name, status: STATUS.REJECTED }
+  meta: { name, status: STATUS.REJECTED },
 })
 
 export {
@@ -37,5 +37,5 @@ export {
   idle,
   pending,
   fulfilled,
-  rejected
+  rejected,
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -8,7 +8,7 @@ export const STATUS = {
 const prefixAT = name => `@@redux-async/${name}`
 const createAT = (name, status) => `${prefixAT(name)}/${status}`
 
-const idle = name => ({
+const reset = name => ({
   type: createAT(name, STATUS.IDLE),
   meta: { name, status: STATUS.IDLE },
 })
@@ -34,7 +34,7 @@ const rejected = (name, error) => ({
 export {
   createAT,
   prefixAT,
-  idle,
+  reset,
   pending,
   fulfilled,
   rejected,

--- a/src/actions.spec.js
+++ b/src/actions.spec.js
@@ -1,0 +1,37 @@
+import { STATUS, idle, pending, fulfilled, rejected } from './actions'
+
+describe('actions', () => {
+  const name = 'NAME'
+
+  // I know the action type could be just this, however, the actions logged on
+  // redux-dev-tools would require us to see its content to know the real intent.
+  // By prefixing the name with `@@redux-async` I scope the actions, and by
+  // appending the status I give them meaning.
+  it('has type prefixed with @@redux-async/NAME', () => {
+    const { type: tIdle } = idle(name)
+    const { type: tPending } = pending(name)
+    const { type: tFulfilled } = fulfilled(name, null)
+    const { type: tRejected } = rejected(name, null)
+
+    const types = [tIdle, tPending, tFulfilled, tRejected]
+    const prefix = new RegExp(`^@@redux-async/${name}`)
+
+    types.forEach(el => expect(el).to.match(prefix))
+  })
+
+  it('has status under `meta`', () => {
+    const { meta: mIdle } = idle(name)
+    const { meta: mPending } = pending(name)
+    const { meta: mFulfilled } = fulfilled(name, null)
+    const { meta: mRejected } = rejected(name, null)
+
+    const pairs = [
+      [mIdle, STATUS.IDLE],
+      [mPending, STATUS.PENDING],
+      [mFulfilled, STATUS.FULFILLED],
+      [mRejected, STATUS.REJECTED],
+    ]
+
+    pairs.forEach(([meta, status]) => expect(meta.status).to.be.equal(status))
+  })
+})

--- a/src/actions.spec.js
+++ b/src/actions.spec.js
@@ -1,4 +1,4 @@
-import { STATUS, idle, pending, fulfilled, rejected } from './actions'
+import { STATUS, reset, pending, fulfilled, rejected } from './actions'
 
 describe('actions', () => {
   const name = 'NAME'
@@ -8,25 +8,25 @@ describe('actions', () => {
   // By prefixing the name with `@@redux-async` I scope the actions, and by
   // appending the status I give them meaning.
   it('has type prefixed with @@redux-async/NAME', () => {
-    const { type: tIdle } = idle(name)
+    const { type: tReset } = reset(name)
     const { type: tPending } = pending(name)
     const { type: tFulfilled } = fulfilled(name, null)
     const { type: tRejected } = rejected(name, null)
 
-    const types = [tIdle, tPending, tFulfilled, tRejected]
+    const types = [tReset, tPending, tFulfilled, tRejected]
     const prefix = new RegExp(`^@@redux-async/${name}`)
 
     types.forEach(el => expect(el).to.match(prefix))
   })
 
   it('has status under `meta`', () => {
-    const { meta: mIdle } = idle(name)
+    const { meta: mReset } = reset(name)
     const { meta: mPending } = pending(name)
     const { meta: mFulfilled } = fulfilled(name, null)
     const { meta: mRejected } = rejected(name, null)
 
     const pairs = [
-      [mIdle, STATUS.IDLE],
+      [mReset, STATUS.IDLE],
       [mPending, STATUS.PENDING],
       [mFulfilled, STATUS.FULFILLED],
       [mRejected, STATUS.REJECTED],

--- a/src/createAC.js
+++ b/src/createAC.js
@@ -23,7 +23,7 @@ const createAC = (name, func) => (...args) => (dispatch, getState) => {
       dispatch(rejected(name, reason))
 
       throw reason
-    }
+    },
   )
 }
 

--- a/src/createAC.spec.js
+++ b/src/createAC.spec.js
@@ -168,7 +168,7 @@ describe('createAC', () => {
       return result.then(() => {
         expect(dispatcher.secondCall.args[0]).to.be.like({
           type: createAT('NAME', STATUS.FULFILLED),
-          payload
+          payload,
         })
       })
     })
@@ -185,7 +185,7 @@ describe('createAC', () => {
         expect(dispatcher.secondCall.args[0]).to.be.like({
           type: createAT('NAME', STATUS.REJECTED),
           payload: error,
-          error: true
+          error: true,
         })
       })
     })

--- a/src/createR.js
+++ b/src/createR.js
@@ -7,8 +7,31 @@ const initialState = {
   data: null,
 }
 
-const createR = (name, reducer = x => x) => (state = initialState, action) => {
-  const { type, payload, meta } = action
+const defaultReducer = (state, action) => {
+  const { type, payload } = action
+
+  switch (type) {
+    case STATUS.PENDING:
+      return {
+        error: null,
+        data: null,
+      }
+    case STATUS.FULFILLED:
+      return {
+        error: null,
+        data: payload,
+      }
+    case STATUS.REJECTED:
+      return {
+        error: payload,
+        data: null,
+      }
+    default: return state
+  }
+}
+
+const createR = (name, reducer = defaultReducer) => (state = initialState, action) => {
+  const { type, meta } = action
 
   if (!meta || (meta && meta.name !== name)) return state
   if (!type || !type.startsWith(prefixAT(name))) return state
@@ -19,30 +42,33 @@ const createR = (name, reducer = x => x) => (state = initialState, action) => {
   switch (meta.status) {
     case STATUS.IDLE:
       return initialState
-    case STATUS.PENDING:
-      reducer(innerState, innerAction)
+    case STATUS.PENDING: {
+      const { error, data } = reducer(innerState, innerAction)
       return {
+        data,
+        error,
         status: STATUS.PENDING,
         loading: true,
-        error: null,
-        data: null,
       }
-    case STATUS.FULFILLED:
-      reducer(innerState, innerAction)
+    }
+    case STATUS.FULFILLED: {
+      const { error, data } = reducer(innerState, innerAction)
       return {
+        data,
+        error,
         status: STATUS.FULFILLED,
         loading: false,
-        error: null,
-        data: payload,
       }
-    case STATUS.REJECTED:
-      reducer(innerState, innerAction)
+    }
+    case STATUS.REJECTED: {
+      const { error, data } = reducer(innerState, innerAction)
       return {
+        data,
+        error,
         status: STATUS.REJECTED,
         loading: false,
-        error: payload,
-        data: null,
       }
+    }
     default:
       return state
   }

--- a/src/createR.js
+++ b/src/createR.js
@@ -11,6 +11,11 @@ const defaultReducer = (state, action) => {
   const { type, payload } = action
 
   switch (type) {
+    case STATUS.IDLE:
+      return {
+        error: null,
+        data: null,
+      }
     case STATUS.PENDING:
       return {
         error: null,
@@ -26,51 +31,66 @@ const defaultReducer = (state, action) => {
         error: payload,
         data: null,
       }
-    default: return state
+    default:
+      return state
   }
 }
 
-const createR = (name, reducer = defaultReducer) => (state = initialState, action) => {
-  const { type, meta } = action
+const trackingReducer = (state, action) => {
+  const { type } = action
 
-  if (!meta || (meta && meta.name !== name)) return state
-  if (!type || !type.startsWith(prefixAT(name))) return state
-
-  const innerState = { error: state.error, data: state.data }
-  const innerAction = { type: meta.status, payload: action.payload, error: action.error }
-
-  switch (meta.status) {
+  switch (type) {
     case STATUS.IDLE:
-      return initialState
-    case STATUS.PENDING: {
-      const { error, data } = reducer(innerState, innerAction)
       return {
-        data,
-        error,
+        status: STATUS.IDLE,
+        loading: false,
+      }
+    case STATUS.PENDING:
+      return {
         status: STATUS.PENDING,
         loading: true,
       }
-    }
-    case STATUS.FULFILLED: {
-      const { error, data } = reducer(innerState, innerAction)
+    case STATUS.FULFILLED:
       return {
-        data,
-        error,
         status: STATUS.FULFILLED,
         loading: false,
       }
-    }
-    case STATUS.REJECTED: {
-      const { error, data } = reducer(innerState, innerAction)
+    case STATUS.REJECTED:
       return {
-        data,
-        error,
         status: STATUS.REJECTED,
         loading: false,
       }
-    }
     default:
       return state
+  }
+}
+
+const guard = name => (action) => {
+  const { type, meta } = action
+
+  if (!meta || (meta && meta.name !== name)) return false
+  if (!type || !type.startsWith(prefixAT(name))) return false
+
+  return true
+}
+
+const createR = (name, resultReducer = defaultReducer) => (state = initialState, action) => {
+  const { meta } = action
+
+  if (!guard(name)(action)) return state
+
+  const innerResultState = { error: state.error, data: state.data }
+  const innerTrackingState = { status: state.status, loading: state.loading }
+  const innerAction = { type: meta.status, payload: action.payload, error: action.error }
+
+  const { error, data } = resultReducer(innerResultState, innerAction)
+  const { status, loading } = trackingReducer(innerTrackingState, innerAction)
+
+  return {
+    status,
+    loading,
+    error,
+    data,
   }
 }
 

--- a/src/createR.js
+++ b/src/createR.js
@@ -11,11 +11,6 @@ const defaultReducer = (state, action) => {
   const { type, payload } = action
 
   switch (type) {
-    case STATUS.IDLE:
-      return {
-        error: null,
-        data: null,
-      }
     case STATUS.PENDING:
       return {
         error: null,
@@ -40,11 +35,6 @@ const trackingReducer = (state, action) => {
   const { type } = action
 
   switch (type) {
-    case STATUS.IDLE:
-      return {
-        status: STATUS.IDLE,
-        loading: false,
-      }
     case STATUS.PENDING:
       return {
         status: STATUS.PENDING,
@@ -67,9 +57,11 @@ const trackingReducer = (state, action) => {
 
 const guard = name => (action) => {
   const { type, meta } = action
+  const statuses = Object.values(STATUS)
 
   if (!meta || (meta && meta.name !== name)) return false
   if (!type || !type.startsWith(prefixAT(name))) return false
+  if (!statuses.includes(meta.status)) return false
 
   return true
 }
@@ -78,6 +70,7 @@ const createR = (name, resultReducer = defaultReducer) => (state = initialState,
   const { meta } = action
 
   if (!guard(name)(action)) return state
+  if (meta.status === STATUS.IDLE) return initialState
 
   const innerResultState = { error: state.error, data: state.data }
   const innerTrackingState = { status: state.status, loading: state.loading }

--- a/src/createR.js
+++ b/src/createR.js
@@ -7,9 +7,7 @@ const initialState = {
   data: null,
 }
 
-const defaultReducer = (state, action) => {
-  const { type, payload } = action
-
+const defaultReducer = (state, { type, payload }) => {
   switch (type) {
     case STATUS.PENDING:
       return {
@@ -31,9 +29,7 @@ const defaultReducer = (state, action) => {
   }
 }
 
-const trackingReducer = (state, action) => {
-  const { type } = action
-
+const trackingReducer = (state, { type }) => {
   switch (type) {
     case STATUS.PENDING:
       return {
@@ -55,8 +51,7 @@ const trackingReducer = (state, action) => {
   }
 }
 
-const guard = name => (action) => {
-  const { type, meta } = action
+const guard = name => ({ type, meta }) => {
   const statuses = Object.values(STATUS)
 
   if (!meta || (meta && meta.name !== name)) return false

--- a/src/createR.js
+++ b/src/createR.js
@@ -7,16 +7,20 @@ const initialState = {
   data: null,
 }
 
-const createR = name => (state = initialState, action) => {
+const createR = (name, reducer = x => x) => (state = initialState, action) => {
   const { type, payload, meta } = action
 
   if (!meta || (meta && meta.name !== name)) return state
   if (!type || !type.startsWith(prefixAT(name))) return state
 
+  const innerState = { error: state.error, data: state.data }
+  const innerAction = { type: meta.status, payload: action.payload, error: action.error }
+
   switch (meta.status) {
     case STATUS.IDLE:
       return initialState
     case STATUS.PENDING:
+      reducer(innerState, innerAction)
       return {
         status: STATUS.PENDING,
         loading: true,
@@ -24,6 +28,7 @@ const createR = name => (state = initialState, action) => {
         data: null,
       }
     case STATUS.FULFILLED:
+      reducer(innerState, innerAction)
       return {
         status: STATUS.FULFILLED,
         loading: false,
@@ -31,6 +36,7 @@ const createR = name => (state = initialState, action) => {
         data: payload,
       }
     case STATUS.REJECTED:
+      reducer(innerState, innerAction)
       return {
         status: STATUS.REJECTED,
         loading: false,

--- a/src/createR.js
+++ b/src/createR.js
@@ -4,36 +4,38 @@ const initialState = {
   status: STATUS.IDLE,
   loading: false,
   error: null,
-  data: null
+  data: null,
 }
 
 const createR = name => (state = initialState, action) => {
   const { type, payload, meta } = action
 
   if (!meta || (meta && meta.name !== name)) return state
-  if (!type.startsWith(prefixAT(name))) return state
+  if (!type || !type.startsWith(prefixAT(name))) return state
 
   switch (meta.status) {
+    case STATUS.IDLE:
+      return initialState
     case STATUS.PENDING:
       return {
         status: STATUS.PENDING,
         loading: true,
         error: null,
-        data: null
+        data: null,
       }
     case STATUS.FULFILLED:
       return {
         status: STATUS.FULFILLED,
         loading: false,
         error: null,
-        data: payload
+        data: payload,
       }
     case STATUS.REJECTED:
       return {
         status: STATUS.REJECTED,
         loading: false,
         error: payload,
-        data: null
+        data: null,
       }
     default:
       return state

--- a/src/createR.spec.js
+++ b/src/createR.spec.js
@@ -46,9 +46,10 @@ describe('createR', () => {
 
   it('returns current state on unknown statuses', () => {
     const state = { loading: false, error: 'asdf', data: [], status: STATUS.REJECTED }
-    const newState = reducer(state, { type: createAT(name, 'SOMETHING'), meta: { name, status: 'SOMETHING' } })
+    const action = { type: createAT(name, 'SOMETHING'), meta: { name, status: 'SOMETHING' } }
+    const newState = reducer(state, action)
 
-    expect(newState).to.be.equal(state)
+    expect(newState).to.be.like(state)
   })
 
   describe('status tracking', () => {
@@ -162,24 +163,16 @@ describe('createR > reducer', () => {
   const name = 'NAME'
   const create = r => createR(name, r)
 
-  it('is not called on idle', () => {
+  it('is called on every action', () => {
     const inner = sinon.fake.returns({})
     const reducer = create(inner)
 
     reducer({}, reset(name))
-
-    expect(inner.callCount).to.be.equal(0)
-  })
-
-  it('is called on pending, fulfilled and rejected', () => {
-    const inner = sinon.fake.returns({})
-    const reducer = create(inner)
-
     reducer({}, pending(name))
     reducer({}, fulfilled(name, null))
     reducer({}, rejected(name, null))
 
-    expect(inner.callCount).to.be.equal(3)
+    expect(inner.callCount).to.be.equal(4)
   })
 
   it('is not called on unknown actions', () => {

--- a/src/createR.spec.js
+++ b/src/createR.spec.js
@@ -1,5 +1,5 @@
 import createR from './createR'
-import { STATUS, pending, fulfilled, rejected } from './actions'
+import { STATUS, createAT, pending, fulfilled, rejected, idle } from './actions'
 
 describe('createR', () => {
   it('handles actions only for that name', () => {
@@ -17,6 +17,42 @@ describe('createR', () => {
 describe('createR > reducer', () => {
   const name = 'NAME'
   const reducer = createR(name)
+
+  it('starts as IDLE and not loading', () => {
+    const state = reducer(undefined, {})
+
+    expect(state.status).to.be.equal(STATUS.IDLE)
+    expect(state.loading).to.be.false
+  })
+
+  it('has no data or error by default', () => {
+    const state = reducer(undefined, {})
+
+    expect(state.data).to.be.null
+    expect(state.error).to.be.null
+  })
+
+  it('returns to initial state on IDLE', () => {
+    const initialState = { status: STATUS.IDLE, loading: false, error: null, data: null }
+    const state = { error: true, data: [], loading: true, status: STATUS.REJECTED }
+    const newState = reducer(state, idle(name))
+
+    expect(newState).to.be.like(initialState)
+  })
+
+  it('returns current state on unknown actions', () => {
+    const state = { loading: false, error: 'asdf', data: [], status: STATUS.REJECTED }
+    const newState = reducer(state, { type: 'UNKNOWN', meta: { name } })
+
+    expect(newState).to.be.equal(state)
+  })
+
+  it('returns current state on unknown statuses', () => {
+    const state = { loading: false, error: 'asdf', data: [], status: STATUS.REJECTED }
+    const newState = reducer(state, { type: createAT(name, 'SOMETHING'), meta: { name, status: 'SOMETHING' } })
+
+    expect(newState).to.be.equal(state)
+  })
 
   describe('status tracking', () => {
     it('starts as IDLE given nothing was executed', () => {

--- a/src/createR.spec.js
+++ b/src/createR.spec.js
@@ -2,21 +2,18 @@ import createR from './createR'
 import { STATUS, createAT, pending, fulfilled, rejected, idle } from './actions'
 
 describe('createR', () => {
+  const name = 'NAME'
+  const reducer = createR(name)
+
   it('handles actions only for that name', () => {
-    const reducer = createR('NAME')
     const state = {}
 
     const untouchedState = reducer(state, pending('ALIAS'))
-    const newState = reducer(state, pending('NAME'))
+    const newState = reducer(state, pending(name))
 
     expect(untouchedState).to.be.equal(state)
     expect(newState).to.not.be.equal(state)
   })
-})
-
-describe('createR > reducer', () => {
-  const name = 'NAME'
-  const reducer = createR(name)
 
   it('starts as IDLE and not loading', () => {
     const state = reducer(undefined, {})
@@ -158,5 +155,69 @@ describe('createR > reducer', () => {
 
       expect(state.data).to.be.null
     })
+  })
+})
+
+describe('createR > reducer', () => {
+  const name = 'NAME'
+  const create = r => createR(name, r)
+
+  it('is not called on idle', () => {
+    const inner = sinon.fake()
+    const reducer = create(inner)
+
+    reducer({}, idle(name))
+
+    expect(inner.callCount).to.be.equal(0)
+  })
+
+  it('is called on pending, fulfilled and rejected', () => {
+    const inner = sinon.fake()
+    const reducer = create(inner)
+
+    reducer({}, pending(name))
+    reducer({}, fulfilled(name, null))
+    reducer({}, rejected(name, null))
+
+    expect(inner.callCount).to.be.equal(3)
+  })
+
+  it('is not called on unknown actions', () => {
+    const inner = sinon.fake()
+    const reducer = create(inner)
+
+    reducer({}, { type: createAT(name, 'SOMETHING'), meta: { status: 'SOMETHING' } })
+
+    expect(inner.callCount).to.be.equal(0)
+  })
+
+  it('is called with current state without status and loading', () => {
+    const inner = sinon.fake()
+    const reducer = create(inner)
+    const state = { status: STATUS.PENDING, loading: true, error: 'asdf', data: [] }
+
+    reducer(state, fulfilled(name, 'qwer'))
+
+    expect(inner.firstCall.args[0]).to.be.like({ error: 'asdf', data: [] })
+  })
+
+  it('receives an action with status as type', () => {
+    const inner = sinon.fake()
+    const reducer = create(inner)
+
+    reducer({}, rejected(name, 'asdf'))
+
+    expect(inner.firstCall.args[1]).to.have.property('type', STATUS.REJECTED)
+  })
+
+  it('receives payload as it comes on main reducer', () => {
+    const inner = sinon.fake()
+    const reducer = create(inner)
+
+    reducer({}, rejected(name, 'asdf'))
+    reducer({}, fulfilled(name, 'qwer'))
+
+    expect(inner.firstCall.args[1]).to.be.like({ error: true, payload: 'asdf' })
+    expect(inner.secondCall.args[1]).to.be.like({ payload: 'qwer' })
   })
 })

--- a/src/createR.spec.js
+++ b/src/createR.spec.js
@@ -49,7 +49,7 @@ describe('createR', () => {
     const action = { type: createAT(name, 'SOMETHING'), meta: { name, status: 'SOMETHING' } }
     const newState = reducer(state, action)
 
-    expect(newState).to.be.like(state)
+    expect(newState).to.be.equal(state)
   })
 
   describe('status tracking', () => {
@@ -163,16 +163,19 @@ describe('createR > reducer', () => {
   const name = 'NAME'
   const create = r => createR(name, r)
 
-  it('is called on every action', () => {
+  it('is called on every action except reset', () => {
     const inner = sinon.fake.returns({})
     const reducer = create(inner)
 
-    reducer({}, reset(name))
     reducer({}, pending(name))
     reducer({}, fulfilled(name, null))
     reducer({}, rejected(name, null))
 
-    expect(inner.callCount).to.be.equal(4)
+    expect(inner.callCount).to.be.equal(3)
+
+    reducer({}, reset(name))
+
+    expect(inner.callCount).to.be.equal(3)
   })
 
   it('is not called on unknown actions', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,5 @@ import createR from './createR'
 
 export {
   createAC,
-  createR
+  createR,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -635,10 +635,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@beblueapp/eslint-config-base@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@beblueapp/eslint-config-base/-/eslint-config-base-0.0.2.tgz#527e9d1765f426c58ea1e026500bb21995858bdd"
-  integrity sha512-/9CZwu5i8VfZjNYcTwl1AWOcRYUCiYmNF/EyYfHarV0u4ya5Ezv6ldjB5hAaHnnxXdolrWRnBmMloqLMCQ/H2w==
+"@beblueapp/eslint-config-base@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@beblueapp/eslint-config-base/-/eslint-config-base-0.0.3.tgz#56de342caee35478c3e327bb7d366a820f6fc8b8"
+  integrity sha512-78h/soF0KmhhHqrmd5CQ1sDUBavIkgED4A+7JUVCTKdI5rRHFtf32kHaZLBiTr3QE5ZK6ydhfJzbNBAnKkG3gA==
   dependencies:
     confusing-browser-globals "^1.0.7"
     object.assign "^4.1.0"


### PR DESCRIPTION
Now we can use a reducer for customizing the state on data and error properties. Before this, if you wanted to have a paginated resource, you'd need to capture the async actions and append/process the data outside of the reducer given by `createR`.

By accepting a second optional parameter as a reducer, `createR` streams the actions to it and uses the returned state. Therefore, to handle paginated resources, you would pass a reducer which joins incoming with current data.

```javascript
const concatReducer = (state, action) => {
  const { type, payload } = action

  switch (type) {
    case STATUS.PENDING: return { ...state, error: null }
    case STATUS.FULFILLED:
      return {
        error: null,
        data: [...state.data, ...payload.elements],
      }
    case STATUS.REJECTED: return { ...state, error: payload }
    default: return state
  }
}

const reducer = createR('FETCH_PRODUCTS', concatReducer)
```

Through the `concatReducer`, we're able to join what we had with the incoming payload, hence, handling continuous pagination.